### PR TITLE
do not write out of bounds and create a hard to find crash

### DIFF
--- a/esp8266-fastled-webserver.ino
+++ b/esp8266-fastled-webserver.ino
@@ -1339,7 +1339,7 @@ void rain(byte backgroundDepth, byte maxBrightness, byte spawnFreq, byte tailLen
 	// Loop for each column individually
 	for (int x = 0; x < MATRIX_WIDTH; x++) {
 		// Step 1.  Move each dot down one cell
-		for (int i = 0; i < MATRIX_HEIGHT; i++) {
+		for (int i = 1; i < MATRIX_HEIGHT; i++) {
 			if (tempMatrix[x][i] >= backgroundDepth) {	// Don't move empty cells
 				if (i > 0) {
 					tempMatrix[x][i-1] = tempMatrix[x][i];


### PR DESCRIPTION
tempMatrix[x][i-1] with i starting at 0 ends up going negative.

While I'm at it, you might also want to look at 
https://github.com/marcmerlin/FastLED_NeoMatrix_SmartMatrix_LEDMatrix_GFX_Demos/blob/master/FastLED/Sublime_Demos/Sublime_Demos.ino
I ended up replacing the arrays with mallocs as creating static arrays was causing more and more issues (i.e. crashes) as my matrix sizes grew. Specifically 
https://github.com/marcmerlin/FastLED_NeoMatrix_SmartMatrix_LEDMatrix_GFX_Demos/blob/master/FastLED/Sublime_Demos/Sublime_Demos.ino#L501